### PR TITLE
Fix `ds3231.h` function signatures to match `ds3231_low_level.c` function signatures

### DIFF
--- a/ds3231.h
+++ b/ds3231.h
@@ -94,9 +94,9 @@ uint8_t ds3231_run_command(uint8_t command);
 uint8_t ds3231_run_status();
 
 void ds3231_I2C_init();
-void time_i2c_write_single(uint8_t device_address, uint8_t register_address, uint8_t data_byte);
+void time_i2c_write_single(uint8_t device_address, uint8_t register_address, uint8_t *data_byte);
 void time_i2c_write_multi(uint8_t device_address, uint8_t start_register_address, uint8_t *data_array, uint8_t data_length);
-void time_i2c_read_single(uint8_t device_address, uint8_t register_address, uint8_t data_byte);
+void time_i2c_read_single(uint8_t device_address, uint8_t register_address, uint8_t *data_byte);
 void time_i2c_read_multi(uint8_t device_address, uint8_t start_register_address, uint8_t *data_array, uint8_t data_length);
 
 #endif


### PR DESCRIPTION
I noticed that the `write_single` functions were passing a byte for `data_byte` instead of a pointer in the header file. It seems like the intended use is for them to pass a pointer.